### PR TITLE
Correct total marks

### DIFF
--- a/docs/marking-individual.md
+++ b/docs/marking-individual.md
@@ -16,7 +16,7 @@ Each form is marked as all-or-nothing.
 | Sprint 4 form                    | 10      |
 | Sprint 5 form                    | 10      |
 | Final individual reflection form | 40      |
-| **Total**                        | **100** |
+| **Total**                        | **90** |
 
 ## Participation
 


### PR DESCRIPTION
In the [Individual Work Assessment page](https://ualberta-cmput401.github.io/course-docs/marking-individual/#reflection-forms), there is a table that shows the worth of each sprint reflection form and final reflection form.
The total marks should be 90 as 10 marks * 5 sprint reflections + 40 marks for final reflection.